### PR TITLE
Added GeoIP_open_type, GeoIP_region_name_by_code and GeoIP_time_zone_by_country_and_region

### DIFF
--- a/geoip-sys/src/lib.rs
+++ b/geoip-sys/src/lib.rs
@@ -2,7 +2,7 @@
 #![warn(non_camel_case_types,
         non_upper_case_globals,
         unused_qualifications)]
-        
+
 extern crate libc;
 
 use libc::{c_void, c_char, c_int, c_ulong, c_float};
@@ -27,6 +27,7 @@ impl GeoIpLookup {
 #[link(name = "GeoIP")]
 extern {
     pub fn GeoIP_open(dbtype: *const c_char, flags: c_int) -> RawGeoIp;
+    pub fn GeoIP_open_type(db_type: c_int, flags: c_int) -> RawGeoIp;
     pub fn GeoIP_delete(db: RawGeoIp);
     pub fn GeoIP_name_by_ipnum_gl(db: RawGeoIp, ipnum: c_ulong, gl: *mut GeoIpLookup) -> *const c_char;
     pub fn GeoIP_name_by_ipnum_v6_gl(db: RawGeoIp, ipnum: In6Addr, gl: *mut GeoIpLookup) -> *const c_char;
@@ -34,6 +35,9 @@ extern {
     pub fn GeoIP_record_by_ipnum_v6(db: RawGeoIp, ipnum: In6Addr) -> *const GeoIpRecord;
     pub fn GeoIPRecord_delete(gir: *const GeoIpRecord);
     pub fn GeoIP_set_charset(db: RawGeoIp, charset: c_int) -> c_int;
+
+    pub fn GeoIP_region_name_by_code(country_code: *const c_char, region_code: *const c_char) -> *const c_char;
+    pub fn GeoIP_time_zone_by_country_and_region(country_code: *const c_char, region_code: *const c_char) -> *const c_char;
 }
 
 #[repr(C)]


### PR DESCRIPTION
I have added this functions:
* `GeoIP_open_type` - open default DB for DBType
* `GeoIP_region_name_by_code` - get "real" region name by region code and country (compiled in C lib)
* `GeoIP_time_zone_by_country_and_region` - get time zone for region code and country (compiled in C lib)