### PR TITLE
DB info & impl Debug for GeoIp

### DIFF
--- a/geoip-sys/src/lib.rs
+++ b/geoip-sys/src/lib.rs
@@ -29,6 +29,7 @@ extern {
     pub fn GeoIP_open(dbtype: *const c_char, flags: c_int) -> RawGeoIp;
     pub fn GeoIP_open_type(db_type: c_int, flags: c_int) -> RawGeoIp;
     pub fn GeoIP_delete(db: RawGeoIp);
+    pub fn GeoIP_database_info(db: RawGeoIp) -> *mut c_char;
     pub fn GeoIP_name_by_ipnum_gl(db: RawGeoIp, ipnum: c_ulong, gl: *mut GeoIpLookup) -> *const c_char;
     pub fn GeoIP_name_by_ipnum_v6_gl(db: RawGeoIp, ipnum: In6Addr, gl: *mut GeoIpLookup) -> *const c_char;
     pub fn GeoIP_record_by_ipnum(db: RawGeoIp, ipnum: c_ulong) -> *const GeoIpRecord;

--- a/src/geoip/lib.rs
+++ b/src/geoip/lib.rs
@@ -16,6 +16,7 @@ use std::ffi;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::path::Path;
 use std::sync::Mutex;
+use std::fmt::{self, Debug};
 
 lazy_static! {
     static ref LOCK: Mutex<()> = Mutex::new(());
@@ -328,6 +329,14 @@ impl Drop for GeoIp {
         unsafe {
             geoip_sys::GeoIP_delete(self.db);
         }
+    }
+}
+
+impl Debug for GeoIp {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("GeoIp")
+            .field("info", &self.info())
+            .finish()
     }
 }
 


### PR DESCRIPTION
I have implemented (hopefully correctly) `info()` function that returns info string about open DB.
I use that information for printing Debug for GeoIp structure. All public types should now have Debug impl.

BTW: I have run `rustfmt` v0.5.0 on the code (via `cargo fmt`).